### PR TITLE
Removes "Unknown Command" Bug for sm_guns

### DIFF
--- a/scripting/retakes.sp
+++ b/scripting/retakes.sp
@@ -332,6 +332,7 @@ public Action Command_Guns(int client, int args) {
         Call_PushCell(client);
         Call_Finish();
     }
+    return Plugin_Handled;
 }
 
 public Action OnClientSayCommand(int client, const char[] command, const char[] args) {


### PR DESCRIPTION
Returns action for command sm_guns to remove the "Unknown Command" bug which appears when a user attempts to put sm_guns (in console)