### PR TITLE
Fix join team bug

### DIFF
--- a/scripting/retakes.sp
+++ b/scripting/retakes.sp
@@ -445,7 +445,7 @@ public Action Event_PlayerTeam(Event event, const char[] name, bool dontBroadcas
         return Plugin_Continue;
     }
 
-    event.BroadcastDisabled = true;
+    SetEventBool(event, "silent", true);
     return Plugin_Continue;
 }
 


### PR DESCRIPTION
Changed sytax in Event_PlayerTeam event hook. This fix no longer requires players to click twice when joining a team.
My previous pull request had unnecessary changes to other calls involving events, but from my testing this is the only change needed to fix the bug.