### PR TITLE
Remove short-handed income messages

### DIFF
--- a/cfg/sourcemod/retakes/retakes_game.cfg
+++ b/cfg/sourcemod/retakes/retakes_game.cfg
@@ -1,6 +1,7 @@
 // Things you shouldn't change:
 bot_kick
 bot_quota 0
+cash_team_bonus_shorthanded 0
 mp_autoteambalance 0
 mp_do_warmup_period 1
 mp_forcecamera 1


### PR DESCRIPTION
The new "Shorthanded Loser Income" will give a T team a bonus $1,000 following a round loss after being a man-down for three or more consecutive rounds. This message is printed to the chat.

It was probably introduced in Release Notes for 1/7/2021, later got renamed to the current cvar in Release Notes for 2/3/2021

![image](https://user-images.githubusercontent.com/1230402/119275865-cdec0980-bc17-11eb-8d42-ca3d9d4c8e57.png)

![image](https://user-images.githubusercontent.com/1230402/119275878-e3613380-bc17-11eb-922d-f3cd9f577876.png)