### PR TITLE
added mp_molotovusedelay 0 to game config

### DIFF
--- a/cfg/sourcemod/retakes/retakes_game.cfg
+++ b/cfg/sourcemod/retakes/retakes_game.cfg
@@ -16,6 +16,7 @@ mp_respawn_on_death_t 0
 mp_solid_teammates 1
 mp_teamcashawards 0
 mp_warmup_pausetimer 0
+mp_molotovusedelay 0
 
 // Things you can change, and may want to:
 mp_autokick 0


### PR DESCRIPTION
Recently when setting up a new server I encountered this pesky cvar `mp_molotovusedelay` which prevents terrorists from using molotovs at the beginning of a round, and it defaults to 15 seconds. I figured this should never be set on a retake server.